### PR TITLE
Better naming `DiConsoleSymfony.php` to `MigrationContainer.php`.

### DIFF
--- a/bin/MigrationContainer.php
+++ b/bin/MigrationContainer.php
@@ -14,7 +14,7 @@ use Yiisoft\Db\Migration\Command\NewCommand;
 use Yiisoft\Db\Migration\Command\RedoCommand;
 use Yiisoft\Db\Migration\Command\UpdateCommand;
 
-final class DiConsoleSymfony
+final class MigrationContainer
 {
     public static function definitions(): array
     {

--- a/bin/migration
+++ b/bin/migration
@@ -4,7 +4,7 @@
 declare(strict_types=1);
 
 require './vendor/autoload.php';
-require 'DiConsoleSymfony.php';
+require 'MigrationContainer.php';
 
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Console\Application;
@@ -12,7 +12,7 @@ use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Di\Container;
 use Yiisoft\Di\ContainerConfig;
 
-$containerConfig = ContainerConfig::create()->withDefinitions(DiConsoleSymfony::definitions());
+$containerConfig = ContainerConfig::create()->withDefinitions(MigrationContainer::definitions());
 $container = new Container($containerConfig);
 
 if ($container->has(CacheInterface::class) === false) {

--- a/docs/en/usage-with-symfony-console.md
+++ b/docs/en/usage-with-symfony-console.md
@@ -1,12 +1,12 @@
 # Symfony Console
 
-1. Copy configuration file `./vendor/yiisoft/db-migration/bin/DiConsoleSymfony.php` to `root` folder of your project.
+1. Copy configuration file `./vendor/yiisoft/db-migration/bin/MigrationContainer.php` to `root` folder of your project.
 
 ```shell
-cp ./vendor/yiisoft/db-migration/bin/DiConsoleSymfony.php ./
+cp ./vendor/yiisoft/db-migration/bin/MigrationContainer.php ./
 ```
 
-2. Edit `./DiConsoleSymfony.php` and add definitions for `Psr\SimpleCache\CacheInterface`
+2. Edit `./MigrationContainer.php` and add definitions for `Psr\SimpleCache\CacheInterface`
    and `Yiisoft\Db\Connection\ConnectionInterface`.
 
 Also, configure `MigrationService::class` and `MigrationInformerInterface::class`.

--- a/docs/en/usage-with-symfony-console.md
+++ b/docs/en/usage-with-symfony-console.md
@@ -35,7 +35,7 @@ use Yiisoft\Db\Sqlite\Connection;
 use Yiisoft\Db\Sqlite\Driver;
 use Yiisoft\Definitions\ReferencesArray;
 
-final class Di
+final class MigrationContainer
 {
     public static function definitions(): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
