### PR TITLE
Fix visability of AbstractMigrationBuilderTest::$db property in tests

### DIFF
--- a/tests/Common/AbstractMigrationBuilderTest.php
+++ b/tests/Common/AbstractMigrationBuilderTest.php
@@ -18,7 +18,7 @@ abstract class AbstractMigrationBuilderTest extends TestCase
 
     protected ContainerInterface $container;
     protected MigrationBuilder $builder;
-    private ConnectionInterface $db;
+    protected ConnectionInterface $db;
     private StubMigrationInformer $informer;
 
     protected function setUp(): void


### PR DESCRIPTION
Before:
https://github.com/yiisoft/db-migration/actions/runs/6072809097/job/16473480240#step:6:16

After:
https://github.com/yiisoft/db-migration/actions/runs/6494238823/job/17636801181?pr=201#step:6:16

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
