### PR TITLE
Remove `yiisoft/definitions` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "yiisoft/aliases": "^1.1|^2.0|^3.0",
         "yiisoft/db": "^1.1",
         "yiisoft/di": "^1.0",
-        "yiisoft/definitions": "^3.0",
         "yiisoft/injector": "^1.0",
         "yiisoft/strings": "^2.0"
     },


### PR DESCRIPTION
It is not used in the package directly but used in `yiisoft/di` package which already has the dependency

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
