### PR TITLE
Fix issue getRawTableName moved to Quoter

### DIFF
--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -138,7 +138,7 @@ final class Migrator
 
     private function createMigrationHistoryTable(): void
     {
-        $tableName = $this->db->getSchema()->getRawTableName($this->historyTable);
+        $tableName = $this->db->getQuoter()->getRawTableName($this->historyTable);
         $this->informer->beginCreateHistoryTable('Creating migration history table "' . $tableName . '"...');
 
         $b = $this->createBuilder(new NullMigrationInformer());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️/❌

In current db-mysql method `getRawTableName` removed, migrations doesn't work. This code fix it.