### PR TITLE
Add `--force-yes` (`-y`) option to `migrate:create`, `migrate:up`, `migrate:down` and `migrate:redo` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Enh #289: Revert transactional migration when adding migration to history fails (@Tigrov)
 - Chg #290: Remove `ext-filter` from `require` section of `composer.json` (@Tigrov)
 - Enh #292: Improve base migration template (@vjik)
+- New #295: Add `--force-yes` (`-y`) option to `migrate:create`, `migrate:up`, `migrate:down` and `migrate:redo`
+  commands to skip confirmation prompts (@vjik)
 
 ## 1.2.0 November 27, 2024
 

--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -85,6 +85,7 @@ final class CreateCommand extends Command
             ->addOption('and', null, InputOption::VALUE_REQUIRED, 'And junction.')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'Path to migration directory.')
             ->addOption('namespace', 'ns', InputOption::VALUE_REQUIRED, 'Migration file namespace.')
+            ->addOption('force-yes', 'y', InputOption::VALUE_NONE, 'Force yes to all questions.')
             ->setHelp('This command generates new migration file.');
     }
 
@@ -155,15 +156,7 @@ final class CreateCommand extends Command
             return Command::INVALID;
         }
 
-        /** @var QuestionHelper $helper */
-        $helper = $this->getHelper('question');
-
-        $question = new ConfirmationQuestion(
-            "\n<fg=cyan>Create new migration y/n: </>",
-            false,
-        );
-
-        if ($helper->ask($input, $output, $question)) {
+        if ($this->confirm($input, $output)) {
             /** @var string|null $fields */
             $fields = $input->getOption('fields');
             /** @var string|null $tableComment */
@@ -191,6 +184,24 @@ final class CreateCommand extends Command
         $this->migrationService->databaseConnection();
 
         return Command::SUCCESS;
+    }
+
+    private function confirm(InputInterface $input, OutputInterface $output): bool
+    {
+        if ($input->getOption('force-yes')) {
+            return true;
+        }
+
+        $question = new ConfirmationQuestion(
+            "\n<fg=cyan>Create new migration y/n: </>",
+            false,
+        );
+
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+
+        /** @var bool */
+        return $helper->ask($input, $output, $question);
     }
 
     private function generateName(string $command, string $name, string|null $and): string

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -53,7 +53,8 @@ final class UpdateCommand extends Command
         $this
             ->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Number of migrations to apply.')
             ->addOption('path', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Path to migrations to apply.')
-            ->addOption('namespace', 'ns', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Namespace of migrations to apply.');
+            ->addOption('namespace', 'ns', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Namespace of migrations to apply.')
+            ->addOption('force-yes', 'y', InputOption::VALUE_NONE, 'Force yes to all questions.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -127,15 +128,7 @@ final class UpdateCommand extends Command
             $output->writeln("\t<fg=yellow>" . ($i + 1) . ". $migration</>");
         }
 
-        /** @var QuestionHelper $helper */
-        $helper = $this->getHelper('question');
-
-        $question = new ConfirmationQuestion(
-            "\n<fg=cyan>Apply the above $migrationWord y/n: ",
-            true
-        );
-
-        if ($helper->ask($input, $output, $question)) {
+        if ($this->confirm($input, $output, $migrationWord)) {
             $instances = $this->migrationService->makeMigrations($migrations);
             $migrationWas = ($migrationsCount === 1 ? 'migration was' : 'migrations were');
 
@@ -157,5 +150,23 @@ final class UpdateCommand extends Command
         $this->migrationService->databaseConnection();
 
         return Command::SUCCESS;
+    }
+
+    private function confirm(InputInterface $input, OutputInterface $output, string $migrationWord): bool
+    {
+        if ($input->getOption('force-yes')) {
+            return true;
+        }
+
+        $question = new ConfirmationQuestion(
+            "\n<fg=cyan>Apply the above $migrationWord y/n: ",
+            true
+        );
+
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+
+        /** @var bool */
+        return $helper->ask($input, $output, $question);
     }
 }

--- a/tests/Common/Command/AbstractCreateCommandTest.php
+++ b/tests/Common/Command/AbstractCreateCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Migration\Tests\Common\Command;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -1095,6 +1096,24 @@ EOF;
             'Only one of `newMigrationNamespace` or `newMigrationPath` should be specified.',
             $output
         );
+    }
+
+    #[TestWith(['--force-yes'])]
+    #[TestWith(['-y'])]
+    public function testForceYes(string $arg): void
+    {
+        $migrationsPath = MigrationHelper::useMigrationsNamespace($this->container);
+
+        $command = $this->createCommand($this->container);
+        $command->setInputs(['no']);
+
+        $exitCode = $command->execute(['name' => 'post', $arg => true]);
+
+        $output = preg_replace('/(\R|\s)+/', ' ', $command->getDisplay(true));
+        $className = MigrationHelper::findMigrationClassNameInOutput($output);
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertFileExists($migrationsPath . '/' . $className . '.php');
     }
 
     public function createCommand(ContainerInterface $container): CommandTester

--- a/tests/Common/Command/AbstractRedoCommandTest.php
+++ b/tests/Common/Command/AbstractRedoCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Migration\Tests\Common\Command;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
@@ -462,6 +463,37 @@ abstract class AbstractRedoCommandTest extends TestCase
         $this->assertSame(Command::SUCCESS, $exitCode);
         $this->assertStringContainsString('Total 1 migration to be redone:', $output);
         $this->assertStringContainsString('1. ' . M231108183919Empty::class, $output);
+    }
+
+    #[TestWith(['--force-yes'])]
+    #[TestWith(['-y'])]
+    public function testForceYes(string $arg): void
+    {
+        MigrationHelper::useMigrationsNamespace($this->container);
+
+        MigrationHelper::createAndApplyMigration(
+            $this->container,
+            'Create_Post',
+            'table',
+            'post',
+            ['name:string(50)'],
+        );
+        MigrationHelper::createAndApplyMigration(
+            $this->container,
+            'Create_User',
+            'table',
+            'user',
+            ['name:string(50)'],
+        );
+
+        $command = $this->createCommand($this->container);
+        $command->setInputs(['no']);
+
+        $exitCode = $command->execute([$arg => true]);
+        $output = preg_replace('/(\R|\s)+/', ' ', $command->getDisplay(true));
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('Migration redone successfully.', $output);
     }
 
     public function createCommand(ContainerInterface $container): CommandTester

--- a/tests/Common/Command/AbstractUpdateCommandTest.php
+++ b/tests/Common/Command/AbstractUpdateCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Migration\Tests\Common\Command;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
@@ -482,6 +483,30 @@ abstract class AbstractUpdateCommandTest extends TestCase
         $this->assertStringContainsString('[ERROR] Not updated.', $output);
 
         $this->container->get(Migrator::class)->down(new $createBookClass());
+    }
+
+    #[TestWith(['--force-yes'])]
+    #[TestWith(['-y'])]
+    public function testForceYes(string $arg): void
+    {
+        MigrationHelper::useMigrationsPath($this->container);
+
+        MigrationHelper::createMigration(
+            $this->container,
+            'Create_Department',
+            'table',
+            'department',
+            ['name:string(50)'],
+        );
+
+        $command = $this->createCommand($this->container);
+        $command->setInputs(['no']);
+
+        $exitCode = $command->execute([$arg => true]);
+        $output = preg_replace('/(\R|\s)+/', ' ', $command->getDisplay(true));
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('>>> Total 1 new migration was applied.', $output);
     }
 
     public function createCommand(ContainerInterface $container): CommandTester


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
