### PR TITLE
Deny pass `null` to `CreateService::getTemplate()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.2 under development
 
-- no changes in this release.
+- Chg #313: Deny pass `null` to `CreateService::getTemplate()` (@KalimeroMK)
 
 ## 2.1.1 August 10, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Yii DB Migration Change Log
 
-## 2.1.2 under development
+## 3.0.0 under development
 
 - Chg #313: Deny pass `null` to `CreateService::getTemplate()` (@KalimeroMK)
+
+## 2.1.2 under development
+
+- no changes in this release.
 
 ## 2.1.1 August 10, 2026
 

--- a/src/Service/Generate/CreateService.php
+++ b/src/Service/Generate/CreateService.php
@@ -87,10 +87,8 @@ final class CreateService
         );
     }
 
-    public function getTemplate(?string $key): string
+    public function getTemplate(string $key): string
     {
-        $key = (string) $key;
-
         if ($this->templates === null) {
             $this->setDefaultTemplates();
         }


### PR DESCRIPTION
Fix #313

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #313

`null` is never passed to `CreateService::getTemplate()`, so the nullable type and the `(string)` cast are removed.