### PR TITLE
Show friendly error on run `yii-db-migration` without configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.2 under development
 
-- no changes in this release.
+- Enh #255: Show friendly error on run `./vendor/bin/yii-db-migration` without configuration file (@KalimeroMK)
 
 ## 2.1.1 August 10, 2026
 

--- a/bin/yii-db-migration
+++ b/bin/yii-db-migration
@@ -25,6 +25,17 @@ $rootPath = dirname(__DIR__, 4);
 /** @psalm-suppress UnresolvableInclude, MissingFile */
 require $_composer_autoload_path ?? $rootPath . '/vendor/autoload.php';
 
+$configFile = $rootPath . '/yii-db-migration.php';
+
+if (!file_exists($configFile)) {
+    fwrite(
+        STDERR,
+        'Configuration file "' . $configFile . '" not found.' . PHP_EOL
+        . 'Copy "' . __DIR__ . '/yii-db-migration.php" to the root folder of your project and configure it.' . PHP_EOL,
+    );
+    exit(1);
+}
+
 /**
  * @psalm-suppress MissingFile
  * @psalm-var array{
@@ -40,7 +51,7 @@ require $_composer_autoload_path ?? $rootPath . '/vendor/autoload.php';
  *     sourcePaths: list<string>,
  * } $params
  */
-$params = require $rootPath . '/yii-db-migration.php';
+$params = require $configFile;
 
 $db = $params['db'] ?? throw new LogicException('DB connection is not configured.');
 

--- a/bin/yii-db-migration
+++ b/bin/yii-db-migration
@@ -31,7 +31,8 @@ if (!file_exists($configFile)) {
     fwrite(
         STDERR,
         'Configuration file "' . $configFile . '" not found.' . PHP_EOL
-        . 'Copy "' . __DIR__ . '/yii-db-migration.php" to the root folder of your project and configure it.' . PHP_EOL,
+        . 'Copy "' . __DIR__ . '/yii-db-migration.php" to the root folder of your project and configure it:' . PHP_EOL
+        . 'cp "' . __DIR__ . '/yii-db-migration.php" "' . $configFile . '"' . PHP_EOL,
     );
     exit(1);
 }

--- a/tests/Migration/BinTest.php
+++ b/tests/Migration/BinTest.php
@@ -54,6 +54,21 @@ final class BinTest extends TestCase
         $this->assertStringContainsString('LogicException: DB connection is not configured.', $output);
     }
 
+    public function testWithoutConfig(): void
+    {
+        unlink(dirname(__DIR__) . '/runtime/bin/yii-db-migration.php');
+
+        [$output, $exitCode] = $this->runYiiDbMigration();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('not found', $output);
+        $this->assertStringContainsString(
+            'cp "' . dirname(__DIR__) . '/runtime/bin/vendor/yiisoft/db-migration/bin/yii-db-migration.php" "'
+            . dirname(__DIR__) . '/runtime/bin/yii-db-migration.php"',
+            $output,
+        );
+    }
+
     private function replaceParams($search, $replace): void
     {
         $file = dirname(__DIR__) . '/runtime/bin/yii-db-migration.php';


### PR DESCRIPTION
Fix #255

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #255

Instead of a PHP warning followed by a fatal error, running `./vendor/bin/yii-db-migration` without a configuration file now prints a friendly message pointing to the template config and exits with code 1:

```
Configuration file "/path/to/yii-db-migration.php" not found.
Copy "/path/to/vendor/yiisoft/db-migration/bin/yii-db-migration.php" to the root folder of your project and configure it.
```